### PR TITLE
Update to the latest V

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /simple_test
+*.ilk
+*.pdb

--- a/miniaudio.c.v
+++ b/miniaudio.c.v
@@ -6,12 +6,18 @@ module miniaudio
 // #flag -I ./miniaudio/c // for the wrapper code
 #flag -I @VROOT/c/miniaudio
 // #flag linux -lpthread -lm -ldl
+
+/* Enables FLAC decoding. */
 #flag -D  DR_FLAC_IMPLEMENTATION
-#include "extras/dr_flac.h"  /* Enables FLAC decoding. */
+#include "extras/dr_flac.h"
+
+/* Enables MP3 decoding. */
 #flag -D  DR_MP3_IMPLEMENTATION
-#include "extras/dr_mp3.h"   /* Enables MP3 decoding. */
+#include "extras/dr_mp3.h"
+
+/* Enables WAV decoding. */
 #flag -D  DR_WAV_IMPLEMENTATION
-#include "extras/dr_wav.h"   /* Enables WAV decoding. */
+#include "extras/dr_wav.h"
 /*
 $if debug {
     #flag -D MA_DEBUG_OUTPUT
@@ -47,6 +53,7 @@ enum Format {
 
 struct C.ma_pcm_converter {}
 
+[heap]
 struct C.ma_decoder {
 	outputFormat     int // Format //C.ma_format
 	outputChannels   u32 // C.ma_uint32

--- a/simple_test.v
+++ b/simple_test.v
@@ -24,9 +24,9 @@ fn test_audio(){
     d.add('sound id 3',s3)
 
     s1.play()
-    time.sleep_ms(50)
+    time.sleep(50 * time.millisecond)
     s3.play()
-    time.sleep_ms(200)
+    time.sleep(200 * time.millisecond)
     s3.seek(20)
     s2.play()
 
@@ -35,11 +35,11 @@ fn test_audio(){
     for ee := s1.length(); ee > 0; ee = ee - 16.377 {
         vol = vol - 0.016
         s1.volume(vol)
-        time.sleep_ms(16)
+        time.sleep(16 * time.millisecond)
     }
     mut longest := int(math.max(s1.length(), s2.length()))
     longest = int(math.max(longest, s3.length()))
-    time.sleep_ms(longest)
+    time.sleep(longest * time.millisecond)
     d.free()
 }
 


### PR DESCRIPTION
I unfortunately don't have a good method to test Linux. This works with MSVC on Windows - I receive missing header files when I try with tcc or gcc.

- #include files with /* */ comment on the same line threw parsing error
- Parsing error with `$if ...` if it precedes a regular `else {`
- Fixed various `unsafe` and deprecation warnings
- Fixed bug with doing a `for ... in ...` loop with the buffers map