### PR TITLE
Add a `sound_from_memory` function to load from []byte

### DIFF
--- a/miniaudio.c.v
+++ b/miniaudio.c.v
@@ -132,6 +132,9 @@ fn C.ma_decoder_uninit(decoder &C.ma_decoder) C.ma_result
 // ma_result ma_decoder_init_file(const char* pFilePath, const ma_decoder_config* pConfig, ma_decoder* pDecoder);
 fn C.ma_decoder_init_file(filepath &char, decoder_config &C.ma_decoder_config, decoder &C.ma_decoder) C.ma_result
 
+// ma_result ma_decoder_init_memory(const void* pData, size_t dataSize, const ma_decoder_config* pConfig, ma_decoder* pDecoder);
+fn C.ma_decoder_init_memory(data voidptr, len u64, decoder_config &C.ma_decoder_config, decoder &C.ma_decoder) C.ma_result
+
 fn C.ma_decoder_get_length_in_pcm_frames(pDecoder &C.ma_decoder) i64
 
 // ma_uint64 ma_decoder_read_pcm_frames(ma_decoder* pDecoder, void* pFramesOut, ma_uint64 frameCount);

--- a/miniaudio.v
+++ b/miniaudio.v
@@ -55,6 +55,33 @@ pub fn sound(filename string) &Sound {
 	return s
 }
 
+// sound_from_memory creates a sound object from the provided byte array
+pub fn sound_from_memory(data []byte) &Sound {
+	decoder_config := C.ma_decoder_config_init(int(Format.f32), 2, 44100)
+	// Init decoder
+	decoder := &C.ma_decoder{}
+	result := int(C.ma_decoder_init_memory(data.data, data.len, &decoder_config, decoder))
+	
+	if result != C.MA_SUCCESS {
+		eprintln('ERROR ' + @MOD+'::' + @FN + ' Failed to init decoder from data (ma_decoder_init_memory ${translate_error_code(result)} )')
+		exit(1)
+	}
+	
+	$if debug {
+		println('INFO ' + @MOD+'::' + @FN + ' Initialized decoder ' + ptr_str(decoder))
+	}
+
+	ab := audio_buffer(decoder)
+	s := &Sound{
+		audio_buffer: ab
+	}
+	
+	$if debug {
+		println('INFO ' + @MOD+'::' + @FN + ' Initialized Sound ' + ptr_str(s))
+	}
+	return s
+}
+
 fn audio_buffer(decoder &C.ma_decoder) &AudioBuffer {
 	ab := &AudioBuffer{
 		volume: 1.0
@@ -160,11 +187,9 @@ pub fn (mut d Device) start() {
 			d.free()
 			exit(1)
 		}
-
-		// TODO BUG Produces a parsing error: https://github.com/vlang/v/issues/10243
-		/*$if debug {
+		$if debug {
 			println('INFO ' +@MOD +'::' + @FN + ' Started device')
-		}*/
+		}
 	} else {
 		$if debug {
 			println('INFO ' + @MOD + '::' + @FN + ' Device already started')
@@ -401,6 +426,10 @@ mut:
 
 pub fn (mut s Sound) play() {
 	s.audio_buffer.playing = true
+}
+
+pub fn (mut s Sound) pause() {
+	s.audio_buffer.playing = false
 }
 
 pub fn (s Sound) length() f64 {


### PR DESCRIPTION
Adds the ability to load a sound from a byte array. I'm using it in my case to load a sound from an embedded file.

Also adds a `pause` method for sounds.